### PR TITLE
[bounty]Fazer Shadowkins Não Tomarem Flash Se Estiverem Com Proteção Contra Flash

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
+# SPDX-FileCopyrightText: 2025 Lucasalemao10 <100492096+Lucasalemao10@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Roudenn <romabond091@gmail.com>
 #

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 GabyChangelog <agentepanela2@gmail.com>
 # SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 # SPDX-FileCopyrightText: 2025 Lucasalemao10 <100492096+Lucasalemao10@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Rouden <149893554+Roudenn@users.noreply.github.com>

--- a/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Body/Organs/shadowkin.yml
@@ -28,7 +28,7 @@
       color: Gray
       activateSound: null
       deactivateSound: null
-    - type: FlashVulnerable # There are downsides.
+# Removido devido a bounty    - type: FlashVulnerable # There are downsides.
 
 - type: entity
   id: OrganShadowkinEars


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->

## Sobre a PR
<!-- O que ela muda? -->
Torna possivel que shadowkins utilizem oculos de proteção contra flash
## Por quê? / Balanceamento
<!-- Discuta do por que da existencia da PR. (opcional | recomendado) -->
Shadowkin no momento so tem traços negativos e quase nenhum positivo
## Detalhes Tecnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requirimentos
<!--Confirme botando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione uma entrada para changelog do servidor, bote o emoji :cl: e siga com as mudanças assim como o exemplo.
:cl: em branco fara com que seu nome na changelog apareça como do github, adicione um nome depois do emoji para mudar seu nome na changelog. -->
🆑 
- tweak: Proteção de flash agora funciona em shadowkins
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
