### PR TITLE
Coesão pra rounds

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -194,9 +194,9 @@
     #- id: RevenantSpawn  # GoobStation - removed till rework
     - id: SleeperAgents
     - id: HereticMidround # Gabystation
-    - id: CosmicCultMidround # Gabystation
-    - id: BloodCultMidround # Gabystation
-    - id: RevolutionaryMidround # Gabystation
+#    - id: CosmicCultMidround # Dumont edit cosmic cult is way too incompatible with other antags
+#    - id: BloodCultMidround # way too incompatible with other antags
+#    - id: RevolutionaryMidround # way too incompatible with other antags
     - id: ZombieOutbreak
     - id: MorphRule # Trauma Port - Gabystation
     - id: LoneOpsSpawn

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -103,10 +103,10 @@
   components:
   - type: SecretPlus
     # if you've come here due to "too many antags", lower chaos change for less midrounds and lower starting chaos for less roundstarts
-    minStartingChaos: 11 # scales per player
-    maxStartingChaos: 22
-    livingChaosChange: -0.018
-    deadChaosChange: 0.020
+    minStartingChaos: 13 # scales per player
+    maxStartingChaos: 23
+    livingChaosChange: -0.015
+    deadChaosChange: 0.016
     # chance for greenshift as well as evilshift
     chaosChangeVariationMin: 0.65
     chaosChangeVariationMax: 1.3

--- a/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
+++ b/Resources/Prototypes/_Goobstation/_Pirates/game_ticking.yml
@@ -16,7 +16,7 @@
   id: SpacePirates
   components:
   - type: StationEvent
-    weight: 3
+    weight: 1
     duration: null
     earliestStart: 20
     reoccurrenceDelay: 60


### PR DESCRIPTION
## Sobre a PR
Remove culto cosmico, culto de sangue e revolucionários de midrounds.
Faz secreto médio ter menos midrounds e um pouco mais startrounds. 
Reduz weight de piratas pra 1 (era 3.)

## Por quê? / Balanceamento
Mudanças solicitadas pela irritação da comunidade.
Rodadas estavam semi-incompreensiveis com todos esses midrounds e antagonistas incompativeis.

## Detalhes Técnicos
Eu posso adicionar mais coisa a isso dependendo de se alguem dizer "Heart também remova [coisa]" ou não.

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
<!-- Adicione um nome depois de :cl: para mudar seu nome no changelog. -->
:cl: Heartbeat
- remove: Midround rev e os dois cultos midround.
- tweak: Secreto médio tem menos midrounds e mais startrounds.
- tweak: Piratas aparecem 1/3 a frequência anterior.
