### PR TITLE
fix: levantar em combate ignorava o knockdown

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -378,24 +378,16 @@ public abstract partial class SharedStunSystem
         if (!Resolve(entity, ref entity.Comp, false))
             return;
 
-        // That way if we fail to stand, the game will try to stand for us when we are able to
+        // Dumont-Levantar: levantar é uma lógica só, dentro e fora de combate. o atalho de
+        // combate levantava instantâneo por 10 de stamina, então bater deitado ignorava o
+        // knockdown. agora todo gatilho cai no mesmo DoAfter do StandTime, mudou lá mudou
+        // em todo lugar
         SetAutoStand(entity, true);
 
         if (StandingBlocked((entity, entity.Comp)))
             return;
 
-        if (!_hands.TryGetEmptyHand(entity.Owner, out _))
-            return;
-
-        if (!TryForceStand(entity.Owner))
-            return;
-
-        // If we have a DoAfter, cancel it
-        CancelKnockdownDoAfter(entity);
-        // Remove Component
-        RemComp<KnockedDownComponent>(entity);
-
-        _adminLogger.Add(LogType.Stamina, LogImpact.Medium, $"{ToPrettyString(entity):user} has force stood up from knockdown.");
+        TryStanding(entity);
     }
 
     private void OnKnockedDownAlert(Entity<KnockedDownComponent> entity, ref KnockedDownAlertEvent args)


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR

levantar do chão em modo de combate era instantâneo.. caiu, trocou pro combate, bateu perto de si e levantou na hora, o knockdown virava nada em briga

agora levantar é uma lógica só, dentro e fora de combate. todo gatilho de levantada forçada (o clique em combate, o ícone de alerta e o verbo de interação) cai no mesmo DoAfter de 2s do levantar normal

## Por quê? / Balanceamento

o atalho de combate levantava na hora por só 10 de stamina, então o tempo de recuperação do knockdown era opcional pra qualquer um em combate. e tinha o agravante do acidente, deitado o próprio sprite ocupa boa parte do clique e o ataque pesado mirado num inimigo do lado acertava o próprio corpo e disparava a levantada sem querer

com a unificação o StandTime do crawler vira o único botão de ajuste. quiser mexer no tempo de levantar, mexe num lugar e vale pra tudo

## Detalhes Técnicos

um método só: o ForceStandUp perdeu a lógica própria (instantâneo + custo de stamina + exigência de mão livre) e passou a delegar pro TryStanding, que é o caminho normal com DoAfter. os três chamadores herdam o comportamento sem precisar de mudança neles

## Anexos

<!-- mudança de mecânica, sem imagem -->

## Requerimentos

- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- fix: levantar do chão em modo de combate não é mais instantâneo, agora leva o mesmo tempo do levantar normal
