### PR TITLE
hotfix(ci): separa o reuse-updater em calcular e aplicar

### DIFF
--- a/.github/workflows/reuse-updater-apply.yml
+++ b/.github/workflows/reuse-updater-apply.yml
@@ -53,6 +53,10 @@ jobs:
           ref: ${{ steps.meta.outputs.head_ref }}
           token: ${{ secrets.BOT_TOKEN }}
           path: pr
+          # da pra baixar pra 1 aqui, so precisamos do HEAD pra aplicar o patch e
+          # commitar, e clonar o historico todo desse repo demora a beca. nao troquei
+          # junto porque workflow_run so roda depois do merge, entao eu nao tinha como
+          # testar se o push aguenta shallow clone. fica pra quem mexer depois
           fetch-depth: 0
 
       - name: Apply patch and push

--- a/.github/workflows/reuse-updater-apply.yml
+++ b/.github/workflows/reuse-updater-apply.yml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Gabriel Raposo <gabriel.henrique7@hotmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Apply REUSE Headers
+
+# workflow_run roda no contexto do repo base, entao aqui tem secret. A diferenca pro
+# pull_request_target antigo e que este job nunca executa codigo do fork: ele so baixa
+# um patch de texto e da git apply. E o push vai pro branch da propria pessoa.
+on:
+  workflow_run:
+    workflows:
+      - Update REUSE Headers
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  apply_headers:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download patch
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: reuse-headers-patch
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: reuse
+
+      - name: Read metadata
+        id: meta
+        if: steps.download.outcome == 'success'
+        run: |
+          set -euo pipefail
+          {
+            echo "head_repo=$(jq -r .head_repo reuse/meta.json)"
+            echo "head_ref=$(jq -r .head_ref reuse/meta.json)"
+            echo "head_sha=$(jq -r .head_sha reuse/meta.json)"
+            echo "pr_number=$(jq -r .pr_number reuse/meta.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR branch
+        if: steps.download.outcome == 'success'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.meta.outputs.head_repo }}
+          ref: ${{ steps.meta.outputs.head_ref }}
+          token: ${{ secrets.BOT_TOKEN }}
+          path: pr
+          fetch-depth: 0
+
+      - name: Apply patch and push
+        if: steps.download.outcome == 'success'
+        working-directory: pr
+        env:
+          EXPECTED_SHA: ${{ steps.meta.outputs.head_sha }}
+          HEAD_REF: ${{ steps.meta.outputs.head_ref }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          COMMIT_USER: ${{ vars.CHANGELOG_USER }}
+          COMMIT_EMAIL: ${{ vars.CHANGELOG_EMAIL }}
+        run: |
+          set -euo pipefail
+
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$CURRENT_SHA" != "$EXPECTED_SHA" ]; then
+            echo "PR #${PR_NUMBER} mudou de $EXPECTED_SHA para $CURRENT_SHA desde que o patch foi gerado."
+            echo "Pulando: a run nova do Update REUSE Headers cuida disso."
+            exit 0
+          fi
+
+          git apply --whitespace=nowarn ../reuse/reuse-headers.patch
+
+          if git diff --quiet; then
+            echo "Patch nao mudou nada, nada a commitar."
+            exit 0
+          fi
+
+          git config user.name "$COMMIT_USER"
+          git config user.email "$COMMIT_EMAIL"
+          git commit -a -m "chore: Automatically update REUSE headers"
+          git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/reuse-updater.yml
+++ b/.github/workflows/reuse-updater.yml
@@ -1,30 +1,34 @@
-      
 # SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aidenkrz <28298836+Aidenkrz@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Gabriel Raposo <gabriel.henrique7@hotmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 name: Update REUSE Headers
 
+# Roda em pull_request de proposito: aqui nao existe secret nenhum, entao rodar em
+# cima do codigo do fork e seguro. Quem commita e o reuse-updater-apply.yml.
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
       - reopened
       - ready_for_review
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
-  update_headers:
+  generate_patch:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          token: ${{ secrets.BOT_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -32,85 +36,95 @@ jobs:
           python-version: '3.11'
 
       - name: Get Changed Files and PR Info
-        id: changed_files
         env:
-           PR_BODY: ${{ github.event.pull_request.body }}
-           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
-           GH_REPO: ${{ github.repository }}
-           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -e # Exit script on first error
+          set -euo pipefail
 
           echo "Fetching files for PR #${PR_NUMBER} in repo ${GH_REPO}"
 
-          PR_FILES_JSON=$(curl -s -f -H "Authorization: token ${GH_TOKEN}" \
-            "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}/files")
+          # --paginate porque sem ele a API devolve so os 30 primeiros arquivos,
+          # e PR grande ficava com a maioria dos arquivos de fora.
+          PR_FILES=$(gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | select(.filename != null) | "\(.status) \(.filename)"')
 
-          if [ $? -ne 0 ]; then
-            echo "Error fetching PR files from GitHub API."
-            exit 1
-          fi
-          
-          if ! echo "$PR_FILES_JSON" | jq -e . > /dev/null; then
-             echo "Warning: Received empty or invalid JSON from GitHub API for PR files."
-             PR_FILES="" # Set PR_FILES to empty to avoid errors below
-          else
-             PR_FILES=$(echo "$PR_FILES_JSON" | jq -r '.[] | select(.filename != null) | "\(.status) \(.filename)"')
-          fi
-
-          if [ -z "$PR_FILES" ]; then
-            echo "No files found in PR."
-            ADDED_FILES=""
-            MODIFIED_FILES=""
-          else
-            ADDED_FILES=$(echo "$PR_FILES" | grep "^added" | grep -E '\.(cs|ya?ml)$' | sed 's/^added //' | xargs) || true
-            MODIFIED_FILES=$(echo "$PR_FILES" | grep "^modified" | grep -E '\.(cs|ya?ml)$' | sed 's/^modified //' | xargs) || true
-          fi
+          ADDED_FILES=$(echo "$PR_FILES" | grep "^added" | grep -E '\.(cs|ya?ml)$' | sed 's/^added //' | xargs) || true
+          MODIFIED_FILES=$(echo "$PR_FILES" | grep "^modified" | grep -E '\.(cs|ya?ml)$' | sed 's/^modified //' | xargs) || true
 
           echo "Added Files: $ADDED_FILES"
           echo "Modified Files: $MODIFIED_FILES"
 
-          echo "ADDED_FILES_LIST<<EOF" >> $GITHUB_ENV
-          echo "$ADDED_FILES" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-          echo "MODIFIED_FILES_LIST<<EOF" >> $GITHUB_ENV
-          echo "$MODIFIED_FILES" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          {
+            echo "ADDED_FILES_LIST<<EOF"
+            echo "$ADDED_FILES"
+            echo "EOF"
+            echo "MODIFIED_FILES_LIST<<EOF"
+            echo "$MODIFIED_FILES"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
           echo "Checking PR body for license..."
           if grep -q "LICENSE: MIT" <<< "$PR_BODY"; then
-            echo "PR_LICENSE=mit" >> $GITHUB_ENV
+            echo "PR_LICENSE=mit" >> "$GITHUB_ENV"
             echo "License specified in PR: MIT"
           elif grep -q "LICENSE: AGPL" <<< "$PR_BODY"; then
-            echo "PR_LICENSE=agpl" >> $GITHUB_ENV
+            echo "PR_LICENSE=agpl" >> "$GITHUB_ENV"
             echo "License specified in PR: AGPL"
           elif grep -q "LICENSE: MPL" <<< "$PR_BODY"; then
-            echo "PR_LICENSE=mpl" >> $GITHUB_ENV
+            echo "PR_LICENSE=mpl" >> "$GITHUB_ENV"
             echo "License specified in PR: MPL"
           else
-            echo "PR_LICENSE=agpl" >> $GITHUB_ENV
+            echo "PR_LICENSE=agpl" >> "$GITHUB_ENV"
             echo "No license specified in PR, using default: AGPL"
           fi
 
       - name: Run REUSE Header Update Script
         run: |
+          set -euo pipefail
           python Tools/update_pr_reuse_headers.py \
-            --files-added ${{ env.ADDED_FILES_LIST }} \
-            --files-modified ${{ env.MODIFIED_FILES_LIST }} \
-            --pr-license ${{ env.PR_LICENSE }} \
-            --pr-base-sha ${{ github.event.pull_request.base.sha }} \
-            --pr-head-sha ${{ github.event.pull_request.head.sha }}
-        working-directory: ${{ github.workspace }}
+            --pr-license "$PR_LICENSE" \
+            --files-added $ADDED_FILES_LIST \
+            --files-modified $MODIFIED_FILES_LIST
 
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Build patch
+        id: patch
+        env:
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet; then
+            echo "No header changes needed."
+            echo "has_patch=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fora do checkout de proposito: o script so mexe em arquivo da PR, mas
+          # o metadado nao pode ser alcancavel por nada que veio do fork.
+          OUT="$RUNNER_TEMP/reuse"
+          mkdir -p "$OUT"
+          git diff > "$OUT/reuse-headers.patch"
+
+          jq -n \
+            --arg repo "$HEAD_REPO" \
+            --arg ref "$HEAD_REF" \
+            --arg sha "$HEAD_SHA" \
+            --arg pr "$PR_NUMBER" \
+            '{head_repo: $repo, head_ref: $ref, head_sha: $sha, pr_number: $pr}' > "$OUT/meta.json"
+
+          echo "has_patch=true" >> "$GITHUB_OUTPUT"
+          cat "$OUT/meta.json"
+
+      - name: Upload patch
+        if: steps.patch.outputs.has_patch == 'true'
+        uses: actions/upload-artifact@v4
         with:
-          commit_message: "chore: Automatically update REUSE headers"
-          commit_user_name: ${{ vars.CHANGELOG_USER }}
-          commit_user_email: ${{ vars.CHANGELOG_EMAIL }}
-          commit_author: ${{ vars.CHANGELOG_USER }} <${{ vars.CHANGELOG_EMAIL }}>
-          skip_dirty_check: false
-          skip_fetch: true
-
-    
+          name: reuse-headers-patch
+          path: ${{ runner.temp }}/reuse
+          retention-days: 1

--- a/.github/workflows/reuse-updater.yml
+++ b/.github/workflows/reuse-updater.yml
@@ -56,6 +56,11 @@ jobs:
 
           # array em vez de string pra nome com espaco nao virar dois argumentos, e
           # ./ na frente pra nome comecando com - nao ser lido como flag do argparse.
+          # o filtro aqui pega so cs/yml/yaml, mas o update_pr_reuse_headers.py sabe
+          # tratar xaml, ftl, py, md e mais um monte. entao arquivo novo desses passa
+          # batido e nao ganha header por aqui. nao mexi junto pra nao misturar com o
+          # hotfix, mas se PR com xaml ou ftl novo estiver quebrando no check de
+          # reuse, o motivo e essa linha
           mapfile -t ADDED < <(grep "^added " <<< "$PR_FILES" | grep -E '\.(cs|ya?ml)$' | sed 's|^added |./|')
           mapfile -t MODIFIED < <(grep "^modified " <<< "$PR_FILES" | grep -E '\.(cs|ya?ml)$' | sed 's|^modified |./|')
 

--- a/.github/workflows/reuse-updater.yml
+++ b/.github/workflows/reuse-updater.yml
@@ -22,6 +22,9 @@ permissions:
 
 jobs:
   generate_patch:
+    # Draft nao recebe header. Commit de reuse no meio do rascunho obriga a ficar
+    # mergindo a toa, o ready_for_review la em cima pega quando a PR sair de draft.
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -35,7 +38,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Get Changed Files and PR Info
+      - name: Run REUSE Header Update Script
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -51,43 +54,30 @@ jobs:
           PR_FILES=$(gh api --paginate "repos/${GH_REPO}/pulls/${PR_NUMBER}/files" \
             --jq '.[] | select(.filename != null) | "\(.status) \(.filename)"')
 
-          ADDED_FILES=$(echo "$PR_FILES" | grep "^added" | grep -E '\.(cs|ya?ml)$' | sed 's/^added //' | xargs) || true
-          MODIFIED_FILES=$(echo "$PR_FILES" | grep "^modified" | grep -E '\.(cs|ya?ml)$' | sed 's/^modified //' | xargs) || true
+          # array em vez de string pra nome com espaco nao virar dois argumentos, e
+          # ./ na frente pra nome comecando com - nao ser lido como flag do argparse.
+          mapfile -t ADDED < <(grep "^added " <<< "$PR_FILES" | grep -E '\.(cs|ya?ml)$' | sed 's|^added |./|')
+          mapfile -t MODIFIED < <(grep "^modified " <<< "$PR_FILES" | grep -E '\.(cs|ya?ml)$' | sed 's|^modified |./|')
 
-          echo "Added Files: $ADDED_FILES"
-          echo "Modified Files: $MODIFIED_FILES"
-
-          {
-            echo "ADDED_FILES_LIST<<EOF"
-            echo "$ADDED_FILES"
-            echo "EOF"
-            echo "MODIFIED_FILES_LIST<<EOF"
-            echo "$MODIFIED_FILES"
-            echo "EOF"
-          } >> "$GITHUB_ENV"
+          echo "Added: ${#ADDED[@]} arquivo(s), modified: ${#MODIFIED[@]} arquivo(s)"
 
           echo "Checking PR body for license..."
           if grep -q "LICENSE: MIT" <<< "$PR_BODY"; then
-            echo "PR_LICENSE=mit" >> "$GITHUB_ENV"
-            echo "License specified in PR: MIT"
+            PR_LICENSE=mit
           elif grep -q "LICENSE: AGPL" <<< "$PR_BODY"; then
-            echo "PR_LICENSE=agpl" >> "$GITHUB_ENV"
-            echo "License specified in PR: AGPL"
+            PR_LICENSE=agpl
           elif grep -q "LICENSE: MPL" <<< "$PR_BODY"; then
-            echo "PR_LICENSE=mpl" >> "$GITHUB_ENV"
-            echo "License specified in PR: MPL"
+            PR_LICENSE=mpl
           else
-            echo "PR_LICENSE=agpl" >> "$GITHUB_ENV"
+            PR_LICENSE=agpl
             echo "No license specified in PR, using default: AGPL"
           fi
+          echo "License: $PR_LICENSE"
 
-      - name: Run REUSE Header Update Script
-        run: |
-          set -euo pipefail
           python Tools/update_pr_reuse_headers.py \
             --pr-license "$PR_LICENSE" \
-            --files-added $ADDED_FILES_LIST \
-            --files-modified $MODIFIED_FILES_LIST
+            --files-added "${ADDED[@]}" \
+            --files-modified "${MODIFIED[@]}"
 
       - name: Build patch
         id: patch


### PR DESCRIPTION
<!--- LICENSE: AGPL -->

## Sobre a PR

o check `update_headers` tá vermelho em toda PR de fork do repo. separei o workflow em dois pra voltar a funcionar sem reabrir o buraco de segurança.

## Por quê? / Balanceamento

o github passou a recusar `actions/checkout` de código de fork dentro de `pull_request_target`. o log diz na cara:

> Refusing to check out fork pull request code from a 'pull_request_target' workflow

e faz sentido. o workflow baixava e rodava código de fork com o `BOT_TOKEN` na mão, que é o "pwn request" clássico, qualquer um abria PR com um script e levava o token.

dá pra religar com `allow-unsafe-pr-checkout: true`, uma linha só, mas aí é assumir o risco de propósito. preferi separar.

## Detalhes Técnicos

`reuse-updater.yml` agora roda em `pull_request`, onde não existe secret nenhum, calcula os headers e sobe o resultado como patch em artifact.

`reuse-updater-apply.yml` roda em `workflow_run`, aí sim com secret, baixa o patch e commita. esse nunca executa código de fork, só dá `git apply` num arquivo de texto, e o push vai pro branch da própria pessoa que abriu a PR.

de quebra arrumei duas coisas que já estavam quebradas antes:

- a chamada da api não paginava, então PR com mais de 30 arquivos ficava com quase tudo de fora
- a lista de arquivos era interpolada direto no `run:` com `${{ }}`, agora vai por env

tem uma guarda pro caso do branch andar entre gerar e aplicar: se o sha mudou, ele pula e deixa a run nova cuidar.

**aviso pra quem for revisar:** `workflow_run` só dispara a partir do workflow que já está na branch padrão. então isso não dá pra ver funcionando nessa PR aqui, só passa a valer depois do merge.

## Requerimentos
- [x] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.
