### PR TITLE
[PORT] Capsulas de Escape pousam em planetas.

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -62,7 +62,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System.Threading;
-using Content.Server.Screens.Components;
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Shared.Access;
@@ -79,10 +78,6 @@ using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Timer = Robust.Shared.Timing.Timer;
-using Content.Server.Explosion.EntitySystems;
-using Content.Server.Chat.Systems;
-using Content.Shared.Chat;
-
 namespace Content.Server.Shuttles.Systems;
 
 // TODO full game saves
@@ -92,6 +87,12 @@ public sealed partial class EmergencyShuttleSystem
     /*
      * Handles the emergency shuttle's console and early launching.
      */
+
+    // Starlight Start: Evacuation pod planet landing
+    private EntityUid? _evacuationPlanetMap;
+    private EntityCoordinates? _evacuationLandingZone;
+    private const float PodSpreadRadius = 25f;
+    // Starlight End
 
     /// <summary>
     /// Has the emergency shuttle arrived?
@@ -270,18 +271,56 @@ public sealed partial class EmergencyShuttleSystem
 
         while (podLaunchQuery.MoveNext(out var uid, out var pod, out var shuttle))
         {
-            var stationUid = _station.GetOwningStation(uid);
+            // Starlight edit Start: Commented out for evacuation pod planet landing
+            // var stationUid = _station.GetOwningStation(uid);
 
-            if (!TryComp<StationCentcommComponent>(stationUid, out var centcomm) ||
-                Deleted(centcomm.Entity) ||
-                pod.LaunchTime == null ||
+            // if (!TryComp<StationCentcommComponent>(stationUid, out var centcomm) ||
+            //     Deleted(centcomm.Entity) ||
+            //     pod.LaunchTime == null ||
+            // Starlight edit End: Commented out for evacuation pod planet landing
+            if (pod.LaunchTime == null || // Starlght Edit: added ``if`` for evacuation pod planet landing
                 pod.LaunchTime > _timing.CurTime)
             {
                 continue;
             }
 
-            // Don't dock them. If you do end up doing this then stagger launch.
-            _shuttle.FTLToDock(uid, shuttle, centcomm.Entity.Value, hyperspaceTime: TransitTime);
+            // Starlight edit Start: Commented out for evacuation pod planet landing
+            // // Don't dock them. If you do end up doing this then stagger launch.
+            // _shuttle.FTLToDock(uid, shuttle, centcomm.Entity.Value, hyperspaceTime: TransitTime + 1 + timeDelay++); //starlight edit, add seconds onto the transit time to ENSURE the emergency shuttle tries to find a dock first
+            // Starlight edit End: Commented out for evacuation pod planet landing
+
+            // Starlight Start: Evacuation pod planet landing
+            if (_evacuationPlanetMap == null || !_evacuationLandingZone.HasValue)
+                SetupEvacuationPlanet();
+
+            if (_evacuationPlanetMap == null || !_evacuationLandingZone.HasValue)
+            {
+                Log.Error($"Evacuation pod {ToPrettyString(uid)} failed to setup evacuation planet destination.");
+                continue;
+            }
+
+            var angle = _random.NextAngle();
+            var distance = _random.NextFloat(0, PodSpreadRadius);
+            var offset = angle.ToVec() * distance;
+            var landingCoords = _evacuationLandingZone.Value.Offset(offset);
+
+            var rotations = new[]
+            {
+                Angle.Zero,
+                Angle.FromDegrees(90),
+                Angle.FromDegrees(180),
+                Angle.FromDegrees(270)
+            };
+            var podRotation = _random.Pick(rotations);
+
+            _shuttle.FTLToCoordinates(
+                uid,
+                shuttle,
+                landingCoords,
+                podRotation,
+                startupTime: 0f,
+                hyperspaceTime: TransitTime + 1 + timeDelay++);
+            // Starlight End: Evacuation pod planet landing
             RemCompDeferred<EscapePodComponent>(uid);
         }
 
@@ -516,5 +555,62 @@ public sealed partial class EmergencyShuttleSystem
         _roundEndCancelToken?.Cancel();
         _roundEndCancelToken = null;
         return true;
+    }
+
+    // Starlight Start: Evacuation pod planet landing
+    /// <summary>
+    /// Creates the evacuation planet for escape pods to land on.
+    /// All pods will land on the same planet with random positions and rotations.
+    /// </summary>
+    private void SetupEvacuationPlanet()
+    {
+        try
+        {
+            // Create a new map for the evacuation planet
+            _mapSystem.CreateMap(out var mapId, runMapInit: false);
+            _evacuationPlanetMap = _mapSystem.GetMap(mapId);
+            
+            if (_evacuationPlanetMap == null)
+            {
+                Log.Error("Failed to create evacuation planet map!");
+                return;
+            }
+            
+            // Generate a biome planet (similar to expedition/arrivals planets)
+            var biomeOptions = new[]
+            {
+                "Grasslands",
+                "Snow"
+            };
+            
+            var selectedBiome = _random.Pick(biomeOptions);
+            
+            if (!_protoManager.TryIndex<BiomeTemplatePrototype>(selectedBiome, out var template))
+            {
+                Log.Error($"Failed to load biome template: {selectedBiome}");
+                return;
+            }
+            
+            // Generate the planet biome
+            _biomes.EnsurePlanet(_evacuationPlanetMap.Value, template);
+            
+            // Set landing zone at center of planet
+            _evacuationLandingZone = new EntityCoordinates(_evacuationPlanetMap.Value, Vector2.Zero);
+            
+            // Initialize the map
+            _mapSystem.InitializeMap(mapId);
+            
+            // Set a nice name
+            _metaData.SetEntityName(_evacuationPlanetMap.Value, "Evacuation Planet");
+            
+            Log.Info($"Created evacuation planet with {selectedBiome} biome");
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to setup evacuation planet: {ex}");
+            _evacuationPlanetMap = null;
+            _evacuationLandingZone = null;
+        }
+    // Starlight End: Evacuation pod planet landing
     }
 }

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -85,6 +85,8 @@ using Content.Shared.Parallax.Biomes;
 using System.Numerics;
 using Content.Shared.Procedural;
 using Robust.Shared.Map.Components;
+using Content.Shared.Chat;
+using Content.Server.Screens.Components;
 // Starlight End
 
 namespace Content.Server.Shuttles.Systems;
@@ -277,6 +279,7 @@ public sealed partial class EmergencyShuttleSystem
         }
 
         var podLaunchQuery = EntityQueryEnumerator<EscapePodComponent, ShuttleComponent>();
+        var timeDelay = 0f;
 
         while (podLaunchQuery.MoveNext(out var uid, out var pod, out var shuttle))
         {
@@ -630,6 +633,7 @@ public sealed partial class EmergencyShuttleSystem
                 foreach (var oreId in oreMarkers)
                 {
                     _biomes.AddMarkerLayer(_evacuationPlanetMap.Value, biomeComp, oreId);
+                    
                 }
             }
 
@@ -640,41 +644,35 @@ public sealed partial class EmergencyShuttleSystem
             var dungeonConfigs = new[]
             {
                 "Experiment",
-                "ShipWreckDungeon",
+                "XenoDungeon",
                 "SovietDungeonWeh",
                 "Mineshaft"
             };
             
-            var numRuins = _random.Next(3, 6); // 3-5 ruins
-            var selectedConfigs = _random.GetItems(dungeonConfigs, numRuins, allowDuplicates: false);
+            var selectedConfig = _random.Pick(dungeonConfigs);
             var seed = _random.Next();
-            var offsetDistance = 50f;
             
-            foreach (var configId in selectedConfigs)
+            var offsetDistance = 80f; 
+            
+            if (_protoManager.TryIndex<DungeonConfigPrototype>(selectedConfig, out var dungeonProto))
             {
-                if (!_protoManager.TryIndex<DungeonConfigPrototype>(configId, out var dungeonProto))
-                {
-                    Log.Warning($"Could not load dungeon config {configId}");
-                    continue;
-                }
-                
-                // Calculate offset position for this ruin
                 var angle = _random.NextAngle();
                 var offset = angle.ToVec() * offsetDistance;
                 var offsetPos = (Vector2i)(Vector2.Zero + offset);
-                
 
-                // Generate the dungeon
                 try
                 {
-                    _dungeon.GenerateDungeon(dungeonProto, _evacuationPlanetMap.Value, grid, offsetPos, seed++);
-                    
-                    Log.Debug($"Generated ruin {configId} at offset {offsetPos}");
+                    _dungeon.GenerateDungeon(dungeonProto, _evacuationPlanetMap.Value, grid, offsetPos, seed);
+                    Log.Info($"Gerada uma única ruin {selectedConfig} no offset {offsetPos}");
                 }
                 catch (Exception e)
                 {
-                    Log.Warning($"Error generating ruin {configId}: {e.Message}");
+                    Log.Warning($"Erro ao gerar a ruin {selectedConfig}: {e.Message}");
                 }
+            }
+            else
+            {
+                Log.Warning($"Não foi possível carregar a config da dungeon {selectedConfig}");
             }
             
             // Set landing zone at center of planet
@@ -686,7 +684,7 @@ public sealed partial class EmergencyShuttleSystem
             // Set a nice name
             _metaData.SetEntityName(_evacuationPlanetMap.Value, "Evacuation Planet");
             
-            Log.Info($"Created evacuation planet with {selectedBiome} biome and {numRuins} ruins");
+            Log.Info($"Created evacuation planet with {selectedBiome} biome and 1 ruin");
         }
         catch (Exception ex)
         {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -100,8 +100,8 @@ public sealed partial class EmergencyShuttleSystem
      */
 
     // Starlight Start: Evacuation pod planet landing
-    private EntityUid? _evacuationPlanetMap;
-    private EntityCoordinates? _evacuationLandingZone;
+    private EntityUid? _evacuationPlanetMap = null;
+    private EntityCoordinates? _evacuationLandingZone = null;
     private const float PodSpreadRadius = 25f;
     // Starlight End
 
@@ -301,10 +301,10 @@ public sealed partial class EmergencyShuttleSystem
             // Starlight edit End: Commented out for evacuation pod planet landing
 
             // Starlight Start: Evacuation pod planet landing
-            if (_evacuationPlanetMap == null || !_evacuationLandingZone.HasValue)
+            if (_evacuationPlanetMap == null || _evacuationLandingZone == null)
                 SetupEvacuationPlanet();
 
-            if (_evacuationPlanetMap == null || !_evacuationLandingZone.HasValue)
+            if (_evacuationPlanetMap == null || _evacuationLandingZone == null)
             {
                 Log.Error($"Evacuation pod {ToPrettyString(uid)} failed to setup evacuation planet destination.");
                 continue;

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -78,6 +78,17 @@ using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Timer = Robust.Shared.Timing.Timer;
+// Starlght Start
+using Robust.Shared.Random;
+using Content.Server.Parallax;
+using Content.Shared.Screen.Components;
+using Content.Shared.Parallax.Biomes;
+using System.Numerics;
+using Content.Server.DeviceNetwork.Components;
+using Content.Shared.Procedural;
+using Robust.Shared.Map.Components;
+// Starlight End
+
 namespace Content.Server.Shuttles.Systems;
 
 // TODO full game saves
@@ -559,7 +570,7 @@ public sealed partial class EmergencyShuttleSystem
 
     // Starlight Start: Evacuation pod planet landing
     /// <summary>
-    /// Creates the evacuation planet for escape pods to land on.
+    /// Creates the evacuation planet for escape pods to land on with ores and ruins.
     /// All pods will land on the same planet with random positions and rotations.
     /// </summary>
     private void SetupEvacuationPlanet()
@@ -580,7 +591,8 @@ public sealed partial class EmergencyShuttleSystem
             var biomeOptions = new[]
             {
                 "Grasslands",
-                "Snow"
+                "Snow",
+                "Caves"
             };
             
             var selectedBiome = _random.Pick(biomeOptions);
@@ -593,6 +605,73 @@ public sealed partial class EmergencyShuttleSystem
             
             // Generate the planet biome
             _biomes.EnsurePlanet(_evacuationPlanetMap.Value, template);
+
+            // Add ore layers to the biome for mining
+            if (TryComp(_evacuationPlanetMap.Value, out BiomeComponent? biomeComp))
+            {
+                var oreMarkers = new[]
+                {
+                    "OreIron",
+                    "OreCoal",
+                    "OreQuartz",
+                    "OreSalt",
+                    "OreGold",
+                    "OreSilver",
+                    "OrePlasma",
+                    "OreUranium",
+                    "OreDiamond",
+                    "OreArtifactFragment"
+                };
+
+                foreach (var oreId in oreMarkers)
+                {
+                    _biomes.AddMarkerLayer(_evacuationPlanetMap.Value, biomeComp, oreId);
+                }
+            }
+
+            // Get the map's grid component for dungeon generation
+            if (!TryComp<MapGridComponent>(_evacuationPlanetMap.Value, out var grid))
+                return;
+
+            var dungeonConfigs = new[]
+            {
+                "Experiment",
+                "ShipWreckDungeon",
+                "SovietDungeonWeh",
+                "Mineshaft"
+            };
+            
+            var numRuins = _random.Next(3, 6); // 3-5 ruins
+            var selectedConfigs = _random.GetItems(dungeonConfigs, numRuins, allowDuplicates: false);
+            var seed = _random.Next();
+            var offsetDistance = 50f;
+            
+            foreach (var configId in selectedConfigs)
+            {
+                if (!_protoManager.TryIndex<DungeonConfigPrototype>(configId, out var dungeonProto))
+                {
+                    Log.Warning($"Could not load dungeon config {configId}");
+                    continue;
+                }
+                
+                // Calculate offset position for this ruin
+                var angle = _random.NextAngle();
+                var offset = angle.ToVec() * offsetDistance;
+                var offsetPos = (Vector2i)(Vector2.Zero + offset);
+                
+
+                // Generate the dungeon
+                try
+                {
+                    _dungeon.GenerateDungeon(dungeonProto, _evacuationPlanetMap.Value, grid, offsetPos, seed++);
+                    
+                    Log.Debug($"Generated ruin {configId} at offset {offsetPos}");
+                }
+                catch (Exception e)
+                {
+                    Log.Warning($"Error generating ruin {configId}: {e.Message}");
+                }
+            }
             
             // Set landing zone at center of planet
             _evacuationLandingZone = new EntityCoordinates(_evacuationPlanetMap.Value, Vector2.Zero);
@@ -603,7 +682,7 @@ public sealed partial class EmergencyShuttleSystem
             // Set a nice name
             _metaData.SetEntityName(_evacuationPlanetMap.Value, "Evacuation Planet");
             
-            Log.Info($"Created evacuation planet with {selectedBiome} biome");
+            Log.Info($"Created evacuation planet with {selectedBiome} biome and {numRuins} ruins");
         }
         catch (Exception ex)
         {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -80,11 +80,9 @@ using Robust.Shared.Prototypes;
 using Timer = Robust.Shared.Timing.Timer;
 // Starlght Start
 using Robust.Shared.Random;
-using Content.Server.Parallax;
 using Content.Shared.Screen.Components;
 using Content.Shared.Parallax.Biomes;
 using System.Numerics;
-using Content.Server.DeviceNetwork.Components;
 using Content.Shared.Procedural;
 using Robust.Shared.Map.Components;
 // Starlight End
@@ -304,7 +302,7 @@ public sealed partial class EmergencyShuttleSystem
             if (_evacuationPlanetMap == null || _evacuationLandingZone == null)
                 SetupEvacuationPlanet();
 
-            if (_evacuationPlanetMap == null || _evacuationLandingZone == null)
+            if (_evacuationPlanetMap == null || _evacuationLandingZone is not { } evacuationLandingZone)
             {
                 Log.Error($"Evacuation pod {ToPrettyString(uid)} failed to setup evacuation planet destination.");
                 continue;
@@ -313,7 +311,7 @@ public sealed partial class EmergencyShuttleSystem
             var angle = _random.NextAngle();
             var distance = _random.NextFloat(0, PodSpreadRadius);
             var offset = angle.ToVec() * distance;
-            var landingCoords = _evacuationLandingZone.Value.Offset(offset);
+            var landingCoords = evacuationLandingZone.Offset(offset);
 
             var rotations = new[]
             {
@@ -469,6 +467,12 @@ public sealed partial class EmergencyShuttleSystem
         TransitTime = MinimumTransitTime + (MaximumTransitTime - MinimumTransitTime) * _random.NextFloat();
         // Round to nearest 10
         TransitTime = MathF.Round(TransitTime / 10f) * 10f;
+
+        // Starlight Start: Evacuation pod planet landing
+        // Clear round-local evacuation planet state so stale map entity IDs are not reused next round.
+        _evacuationPlanetMap = null;
+        _evacuationLandingZone = null;
+        // Starlight End
     }
 
     private void UpdateAllEmergencyConsoles()

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.Console.cs
@@ -96,7 +96,7 @@ namespace Content.Server.Shuttles.Systems;
 public sealed partial class EmergencyShuttleSystem
 {
     /*
-     * Handles the emergency shuttle's console and early launching.
+     * Handles the emergency shuttle's console and early launching
      */
 
     // Starlight Start: Evacuation pod planet landing

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -111,13 +111,12 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 // Starlight Start
-using Content.Server._Starlight.Station;
-using Content.Shared._Starlight.CustomObjectiveSummary;
 using Content.Shared.Station.Components;
 using Content.Server.Parallax;
 using Content.Shared.Parallax.Biomes;
 using Content.Server.Procedural;
 using Robust.Shared.Map;
+using Content.Shared.Random;
 // Starlight End
 
 namespace Content.Server.Shuttles.Systems;
@@ -128,33 +127,33 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
      * Handles the escape shuttle + CentCom.
      */
 
-    [Dependency] private readonly IAdminLogManager _logger = default!;
-    [Dependency] private readonly IAdminManager _admin = default!;
-    [Dependency] private readonly IConfigurationManager _configManager = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly SharedMapSystem _mapSystem = default!;
-    [Dependency] private readonly AccessReaderSystem _reader = default!;
-    [Dependency] private readonly ChatSystem _chatSystem = default!;
-    [Dependency] private readonly CommunicationsConsoleSystem _commsConsole = default!;
-    [Dependency] private readonly DeviceNetworkSystem _deviceNetworkSystem = default!;
-    [Dependency] private readonly DockingSystem _dock = default!;
-    [Dependency] private readonly IdCardSystem _idSystem = default!;
-    [Dependency] private readonly NavMapSystem _navMap = default!;
-    [Dependency] private readonly MapLoaderSystem _loader = default!;
-    [Dependency] private readonly MetaDataSystem _metaData = default!;
-    [Dependency] private readonly PopupSystem _popup = default!;
-    [Dependency] private readonly RoundEndSystem _roundEnd = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly ShuttleSystem _shuttle = default!;
-    [Dependency] private readonly StationSystem _station = default!;
-    [Dependency] private readonly TransformSystem _transformSystem = default!;
-    [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
+    [Dependency] private IAdminLogManager _logger = default!;
+    [Dependency] private IAdminManager _admin = default!;
+    [Dependency] private ExplosionSystem _explosion = default!;
+    [Dependency] private IConfigurationManager _configManager = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private SharedMapSystem _mapSystem = default!;
+    [Dependency] private AccessReaderSystem _reader = default!;
+    [Dependency] private ChatSystem _chatSystem = default!;
+    [Dependency] private CommunicationsConsoleSystem _commsConsole = default!;
+    [Dependency] private DeviceNetworkSystem _deviceNetworkSystem = default!;
+    [Dependency] private DockingSystem _dock = default!;
+    [Dependency] private IdCardSystem _idSystem = default!;
+    [Dependency] private NavMapSystem _navMap = default!;
+    [Dependency] private MapLoaderSystem _loader = default!;
+    [Dependency] private MetaDataSystem _metaData = default!;
+    [Dependency] private PopupSystem _popup = default!;
+    [Dependency] private RoundEndSystem _roundEnd = default!;
+    [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private ShuttleSystem _shuttle = default!;
+    [Dependency] private StationSystem _station = default!;
+    [Dependency] private TransformSystem _transformSystem = default!;
+    [Dependency] private UserInterfaceSystem _uiSystem = default!;
     // Starlight Start
-    [Dependency] private readonly IMapManager _mapManager = default!;
-    [Dependency] private readonly IPrototypeManager _protoManager = default!;
-    [Dependency] private readonly BiomeSystem _biomes = default!;
-    [Dependency] private readonly DungeonSystem _dungeon = default!;
+    [Dependency] private IPrototypeManager _protoManager = default!;
+    [Dependency] private BiomeSystem _biomes = default!;
+    [Dependency] private DungeonSystem _dungeon = default!;
     // Starlight End
 
     private const float ShuttleSpawnBuffer = 1f;
@@ -610,16 +609,6 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
             return;
         }
 
-        // Gabystation change start
-        if (!_prototype.TryIndex<WeightedRandomPrototype>(MapsProto, out var maps))
-        {
-            Log.Error($"Random centcomm prototype '{MapsProto}' not found. Using default centcomm map.");
-        }
-        else
-        {
-            component.Map = new ResPath(maps.Pick(_random));
-        }
-        // Gabystation change end
 
         if (string.IsNullOrEmpty(component.Map.ToString()))
         {

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -116,6 +116,8 @@ using Content.Shared._Starlight.CustomObjectiveSummary;
 using Content.Shared.Station.Components;
 using Content.Server.Parallax;
 using Content.Shared.Parallax.Biomes;
+using Content.Server.Procedural;
+using Robust.Shared.Map;
 // Starlight End
 
 namespace Content.Server.Shuttles.Systems;
@@ -149,8 +151,10 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     // Starlight Start
+    [Dependency] private readonly IMapManager _mapManager = default!;
     [Dependency] private readonly IPrototypeManager _protoManager = default!;
     [Dependency] private readonly BiomeSystem _biomes = default!;
+    [Dependency] private readonly DungeonSystem _dungeon = default!;
     // Starlight End
 
     private const float ShuttleSpawnBuffer = 1f;

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -110,8 +110,13 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Content.Shared.Random;
-using Content.Shared.Random.Helpers;
+// Starlight Start
+using Content.Server._Starlight.Station;
+using Content.Shared._Starlight.CustomObjectiveSummary;
+using Content.Shared.Station.Components;
+using Content.Server.Parallax;
+using Content.Shared.Parallax.Biomes;
+// Starlight End
 
 namespace Content.Server.Shuttles.Systems;
 
@@ -143,17 +148,16 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     [Dependency] private readonly StationSystem _station = default!;
     [Dependency] private readonly TransformSystem _transformSystem = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly IPrototypeManager _prototype = default!; // Gabystation change
-    [Dependency] private readonly ExplosionSystem _explosion = default!; // Goob edit
+    // Starlight Start
+    [Dependency] private readonly IPrototypeManager _protoManager = default!;
+    [Dependency] private readonly BiomeSystem _biomes = default!;
+    // Starlight End
 
     private const float ShuttleSpawnBuffer = 1f;
 
     private bool _emergencyShuttleEnabled;
 
     private static readonly ProtoId<TagPrototype> DockTag = "DockEmergency";
-
-    [ValidatePrototypeId<WeightedRandomPrototype>]
-    private const string MapsProto = "CentcommWeights"; // Gabystation change
 
     public override void Initialize()
     {

--- a/Content.Shared/Screen/Components/ScreenTimerComponent.cs
+++ b/Content.Shared/Screen/Components/ScreenTimerComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared.Screen.Components;
+
+/// <summary>
+/// Added to an entity already containing a <see cref="ScreenVisualsComponent"/> to track frame-by-frame timer updates
+/// </summary>
+[RegisterComponent]
+public sealed partial class ScreenTimerComponent : Component
+{
+    [DataField("targetTime", customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan Target = TimeSpan.Zero;
+    public Dictionary<string, string?> LayerStatesToDraw = new();
+}


### PR DESCRIPTION
## Sobre a PR
Agora as capsulas de escape/emergência pousam em planetas, porta: https://github.com/ss14Starlight/space-station-14/pull/3596
## Por quê? / Balanceamento
Pods de emergência é conceitualmente feitos para pousar em planetas próximos ou ficarem a deriva no espaço, faz sentido.
Isso também tornar a gameplay de fuga pelo pod mais interessante.

## Detalhes Técnicos

## Anexos
<img width="708" height="717" alt="image" src="https://github.com/user-attachments/assets/b6733309-82fa-463d-81b3-023025976b3b" />

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl: Struater
- tweak: Pods de escape agora pousam em planetas
