### PR TITLE
arruma crash do cliente ao reiniciar o round

### DIFF
--- a/Content.Goobstation.Client/Particles/ParticleData.cs
+++ b/Content.Goobstation.Client/Particles/ParticleData.cs
@@ -77,7 +77,17 @@ public sealed class ParticleData
 
     public void Reset()
     {
+        LocalOffset = default;
+        SpawnOrigin = default;
+        Velocity = default;
         Age = TimeSpan.Zero;
+        Lifetime = TimeSpan.FromSeconds(1);
+        SpawnSpeed = 0f;
+        SpawnIntensity = 1f;
+        Rotation = 0f;
+        RotationSpeed = 0f;
         Alive = false;
+        SizeMultiplier = 1f;
+        NoiseOffset = default;
     }
 }

--- a/Content.Goobstation.Client/Particles/ParticleOverlay.cs
+++ b/Content.Goobstation.Client/Particles/ParticleOverlay.cs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using System.Linq;
 using System.Numerics;
 using Robust.Client.Graphics;
 using Robust.Shared.Enums;
@@ -16,21 +17,12 @@ public sealed class ParticleOverlay : Overlay
     [Dependency] private readonly IPrototypeManager _proto = default!;
 
     private readonly ParticleSystem _system;
-    private readonly Dictionary<string, ShaderInstance?> _shaderCache = new();
-    private readonly List<ActiveEmitter> _sortBuffer = new();
-    private static readonly Comparison<ActiveEmitter> RenderLayerComparison =
-        (a, b) => (a.Overrides?.RenderLayer ?? a.Proto.RenderLayer)
-            .CompareTo(b.Overrides?.RenderLayer ?? b.Proto.RenderLayer);
+    private readonly Dictionary<string, ShaderInstance> _shaderCache = new();
 
     public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowFOV;
 
     // Engine cap on quads per <c>DrawPrimitives</c> call, we never want to feed more than this in a single submit.
     private const int MaxQuadsPerDraw = 16383;
-
-    private static readonly Vector2 Uv2BL = new(0f, 0f);
-    private static readonly Vector2 Uv2BR = new(1f, 0f);
-    private static readonly Vector2 Uv2TR = new(1f, 1f);
-    private static readonly Vector2 Uv2TL = new(0f, 1f);
 
     private readonly DrawVertexUV2DColor[] _vertexScratch = new DrawVertexUV2DColor[MaxQuadsPerDraw * 4];
     private readonly ushort[] _indexScratch;
@@ -82,15 +74,11 @@ public sealed class ParticleOverlay : Overlay
         var cosR = MathF.Cos(-eyeAngle);
         var sinR = MathF.Sin(-eyeAngle);
 
-        _sortBuffer.Clear();
-        var live = _system.GetEmitters();
-        for (var i = 0; i < live.Count; i++)
-            _sortBuffer.Add(live[i]);
-        _sortBuffer.Sort(RenderLayerComparison);
+        var sorted = _system.GetEmitters().OrderBy(e => e.Overrides?.RenderLayer ?? e.Proto.RenderLayer);
 
         string? activeShader = null;
 
-        foreach (var emitter in _sortBuffer)
+        foreach (var emitter in sorted)
         {
             if (emitter.MapCoords.MapId != mapId) continue;
             if (!args.WorldBounds.Contains(emitter.MapCoords.Position)) continue;
@@ -110,8 +98,10 @@ public sealed class ParticleOverlay : Overlay
                     if (!_shaderCache.TryGetValue(wantedShader, out var cached))
                     {
                         if (_proto.Resolve<ShaderPrototype>(wantedShader, out var shaderProto))
+                        {
                             cached = shaderProto.Instance();
-                        _shaderCache[wantedShader] = cached;
+                            _shaderCache[wantedShader] = cached;
+                        }
                     }
                     handle.UseShader(cached);
                 }
@@ -137,22 +127,18 @@ public sealed class ParticleOverlay : Overlay
             var uvTR = uv.TopRight;
             var uvTL = uv.TopLeft;
 
+            var uv2BL = new Vector2(0f, 0f);
+            var uv2BR = new Vector2(1f, 0f);
+            var uv2TR = new Vector2(1f, 1f);
+            var uv2TL = new Vector2(0f, 1f);
+
             var verts = _vertexScratch.AsSpan();
             var quadCount = 0;
 
             foreach (var particle in emitter.Particles)
             {
                 if (!particle.Alive) continue;
-
-                if (quadCount >= MaxQuadsPerDraw)
-                {
-                    handle.DrawPrimitives(
-                        DrawPrimitiveTopology.TriangleList,
-                        drawTex,
-                        _indexScratch.AsSpan(0, quadCount * 6),
-                        verts.Slice(0, quadCount * 4));
-                    quadCount = 0;
-                }
+                if (quadCount >= MaxQuadsPerDraw) break;
 
                 var t = particle.AgeRatio;
 
@@ -184,16 +170,14 @@ public sealed class ParticleOverlay : Overlay
                 float halfX = halfSize;
                 float halfY = halfSize;
                 float cos, sin;
-                var velSq = particle.Velocity.LengthSquared();
-                if (stretchFactor > 0f && velSq > 0.000001f)
+                if (stretchFactor > 0f && particle.Velocity.LengthSquared() > 0.000001f)
                 {
-                    var velLen = MathF.Sqrt(velSq);
+                    var velLen = particle.Velocity.Length();
                     halfY = halfSize * (1f + velLen * stretchFactor);
-                    var invLen = 1f / velLen;
-                    var cosVel = particle.Velocity.Y * invLen;
-                    var sinVel = particle.Velocity.X * invLen;
-                    cos = cosR * cosVel - sinR * sinVel;
-                    sin = sinR * cosVel + cosR * sinVel;
+                    var velAngle = MathF.Atan2(particle.Velocity.X, particle.Velocity.Y);
+                    var totalRot = -eyeAngle + velAngle;
+                    cos = MathF.Cos(totalRot);
+                    sin = MathF.Sin(totalRot);
                 }
                 else
                 {
@@ -219,10 +203,10 @@ public sealed class ParticleOverlay : Overlay
                 var tlY = -hxS + hyC + ty;
 
                 var v = quadCount * 4;
-                verts[v + 0] = new DrawVertexUV2DColor(new Vector2(blX, blY), uvBL, color) { UV2 = Uv2BL };
-                verts[v + 1] = new DrawVertexUV2DColor(new Vector2(brX, brY), uvBR, color) { UV2 = Uv2BR };
-                verts[v + 2] = new DrawVertexUV2DColor(new Vector2(trX, trY), uvTR, color) { UV2 = Uv2TR };
-                verts[v + 3] = new DrawVertexUV2DColor(new Vector2(tlX, tlY), uvTL, color) { UV2 = Uv2TL };
+                verts[v + 0] = new DrawVertexUV2DColor(new Vector2(blX, blY), uvBL, color) { UV2 = uv2BL };
+                verts[v + 1] = new DrawVertexUV2DColor(new Vector2(brX, brY), uvBR, color) { UV2 = uv2BR };
+                verts[v + 2] = new DrawVertexUV2DColor(new Vector2(trX, trY), uvTR, color) { UV2 = uv2TR };
+                verts[v + 3] = new DrawVertexUV2DColor(new Vector2(tlX, tlY), uvTL, color) { UV2 = uv2TL };
 
                 quadCount++;
             }
@@ -237,7 +221,6 @@ public sealed class ParticleOverlay : Overlay
                 verts.Slice(0, quadCount * 4));
         }
 
-        _sortBuffer.Clear();
         handle.UseShader(null);
     }
 }

--- a/Content.Goobstation.Client/Particles/ParticleSystem.cs
+++ b/Content.Goobstation.Client/Particles/ParticleSystem.cs
@@ -32,54 +32,10 @@ public sealed partial class ParticleSystem : EntitySystem
 
     private readonly List<ActiveEmitter> _emitters = new();
     private readonly List<(ProtoId<ParticleEffectPrototype> Id, MapCoordinates Coords)> _pendingSubEmitters = new();
-    private readonly Dictionary<ParticleEffectPrototype, (Texture[] Frames, float[] Delays)> _frameCache = new();
-    private readonly HashSet<ParticleEffectPrototype> _frameResolveFailures = new();
     private ParticleOverlay _particleOverlay = default!;
 
     private int _quality;
-
-    /// <summary>
-    /// Manual override from <see cref="GoobCVars.ParticleGlobalBudget"/>.
-    /// </summary>
-    private int _manualBudget;
-
-    /// <summary>
-    /// Effective global budget for the current frame, derived from <see cref="_quality"/> and <see cref="_manualBudget"/>.
-    /// </summary>
     private int _globalBudget;
-
-    /// <summary>
-    /// Running tally of <see cref="ParticleEffectPrototype.IgnoreQualitySettings"/> emitters in
-    /// <see cref="_emitters"/> so the quality-0 spawn cap doesn't have to scan the whole list every frame.
-    /// </summary>
-    private int _ignoreQualityEmitterCount;
-
-    /// <summary>
-    /// Running tally of all live particles across every emitter. Incremented in
-    /// <see cref="EmitParticle"/>, decremented anywhere a particle's alive state gets set to false.
-    /// </summary>
-    private int _liveParticleCount;
-
-    private static readonly Predicate<ActiveEmitter> RemoveNonIgnoreQualityPredicate =
-        e => !e.Proto.IgnoreQualitySettings;
-
-    private const float TeleportThresholdSquared = 16f * 16f;
-
-    private const float MinParticleLifetimeSeconds = 0.05f;
-
-    /// <summary>
-    /// Eye view-bounds buffer used by the simulation. Off-screen emitters within this padded box
-    /// still simulate so particles already in flight aren't frozen at the screen edge.
-    /// </summary>
-    private const float ViewBoundsPaddingFactor = 1.5f;
-
-    private const int MaxIgnoreQualityEmittersAtZero = 8;
-
-    /// <summary>
-    /// Hard cap on sub-emitter spawns chained from a single tick. Stops
-    /// SubEmitterOnSpawn -> SubEmitterOnSpawn cycles killing the client down with infinite recursion :(
-    /// </summary>
-    private const int MaxSubEmittersPerTick = 256;
 
     /// <summary>
     /// Incrementing handle counter. Old values are abandoned when emitters die, handles are never reused.
@@ -135,56 +91,22 @@ public sealed partial class ParticleSystem : EntitySystem
         _overlay.AddOverlay(_particleOverlay);
 
         _cfg.OnValueChanged(GoobCVars.ParticleQuality, OnQualityChanged, invokeImmediately: true);
-        _cfg.OnValueChanged(GoobCVars.ParticleGlobalBudget, OnManualBudgetChanged, invokeImmediately: true);
-
-        _proto.PrototypesReloaded += OnPrototypesReloaded;
+        _cfg.OnValueChanged(GoobCVars.ParticleGlobalBudget, v => _globalBudget = v, invokeImmediately: true);
     }
 
     public override void Shutdown()
     {
         base.Shutdown();
         _cfg.UnsubValueChanged(GoobCVars.ParticleQuality, OnQualityChanged);
-        _cfg.UnsubValueChanged(GoobCVars.ParticleGlobalBudget, OnManualBudgetChanged);
-        _proto.PrototypesReloaded -= OnPrototypesReloaded;
         _overlay.RemoveOverlay(_particleOverlay);
         _emitters.Clear();
-        _pendingSubEmitters.Clear();
-        _frameCache.Clear();
-        _frameResolveFailures.Clear();
-        _ignoreQualityEmitterCount = 0;
-        _liveParticleCount = 0;
     }
 
     private void OnQualityChanged(int quality)
     {
         _quality = quality;
-        RecomputeBudget();
-    }
-
-    private void OnManualBudgetChanged(int budget)
-    {
-        _manualBudget = budget;
-        RecomputeBudget();
-    }
-
-
-    private void RecomputeBudget()
-    {
-        var qualityBudget = _quality >= 0 && _quality < QualityBudgets.Length
-            ? QualityBudgets[_quality]
-            : 0;
-
-        _globalBudget = _quality >= QualityBudgets.Length - 1
-            ? Math.Min(_manualBudget, HardMaxParticles)
-            : qualityBudget;
-    }
-
-    private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
-    {
-        if (!args.WasModified<ParticleEffectPrototype>())
-            return;
-        _frameCache.Clear();
-        _frameResolveFailures.Clear();
+        if (quality >= 0 && quality < QualityBudgets.Length)
+            _globalBudget = QualityBudgets[quality];
     }
 
     public IReadOnlyList<ActiveEmitter> GetEmitters() => _emitters;
@@ -198,9 +120,6 @@ public sealed partial class ParticleSystem : EntitySystem
     {
         var count = _emitters.Count;
         _emitters.Clear();
-        _pendingSubEmitters.Clear();
-        _ignoreQualityEmitterCount = 0;
-        _liveParticleCount = 0;
         return count;
     }
 
@@ -217,29 +136,29 @@ public sealed partial class ParticleSystem : EntitySystem
             return null;
 
         // Skip quality check if this is a gameplay-critical particle
-        if (_quality == 0)
-        {
-            if (!proto.IgnoreQualitySettings)
-                return null;
+        if (_quality == 0 && !proto.IgnoreQualitySettings)
+            return null;
 
-            // Even IgnoreQualitySettings effects are capped at 8 simultaneous emitters when quality is Off.
-            if (_ignoreQualityEmitterCount >= MaxIgnoreQualityEmittersAtZero)
+        // Even IgnoreQualitySettings effects are capped at 8 simultaneous emitters when quality is Off.
+        if (_quality == 0 && proto.IgnoreQualitySettings)
+        {
+            var ignoreQualityEmitterCount = 0;
+            foreach (var e in _emitters)
+            {
+                if (e.Proto.IgnoreQualitySettings)
+                    ignoreQualityEmitterCount++;
+            }
+            if (ignoreQualityEmitterCount >= 8)
                 return null;
         }
 
         var emitter = CreateEmitter(proto, coords, attachedEntity);
         emitter.ColorOverride = colorOverride;
 
-        _emitters.Add(emitter);
-        if (proto.IgnoreQualitySettings)
-            _ignoreQualityEmitterCount++;
-
         if (proto.Burst)
-        {
             BurstEmit(emitter);
-            emitter.Exhausted = true;
-        }
 
+        _emitters.Add(emitter);
         return emitter;
     }
 
@@ -318,10 +237,10 @@ public sealed partial class ParticleSystem : EntitySystem
         EntityUid targetEntity,
         EntityUid? attachedEntity = null)
     {
-        Vector2? targetPos = null;
-        if (!Deleted(targetEntity))
-            targetPos = _transform.GetMapCoordinates(targetEntity).Position;
-        return SpawnEffectAimedInternal(effectId, coords, targetEntity, targetPos, attachedEntity);
+        var emitter = SpawnEffect(effectId, coords, attachedEntity);
+        if (emitter != null)
+            emitter.TargetEntity = targetEntity;
+        return emitter;
     }
 
     /// <summary>
@@ -333,202 +252,71 @@ public sealed partial class ParticleSystem : EntitySystem
         Vector2 targetWorldPosition,
         EntityUid? attachedEntity = null)
     {
-        return SpawnEffectAimedInternal(effectId, coords, null, targetWorldPosition, attachedEntity);
-    }
-
-    private ActiveEmitter? SpawnEffectAimedInternal(
-        ProtoId<ParticleEffectPrototype> effectId,
-        MapCoordinates coords,
-        EntityUid? targetEntity,
-        Vector2? targetPosition,
-        EntityUid? attachedEntity)
-    {
-        if (!_proto.Resolve(effectId, out var proto))
-            return null;
-
-        if (_quality == 0)
-        {
-            if (!proto.IgnoreQualitySettings)
-                return null;
-            if (_ignoreQualityEmitterCount >= MaxIgnoreQualityEmittersAtZero)
-                return null;
-        }
-
-        var emitter = CreateEmitter(proto, coords, attachedEntity);
-        emitter.TargetEntity = targetEntity;
-        emitter.TargetPosition = targetPosition;
-
-        // Resolve aim angle BEFORE the burst so the burst actually points where it should.
-        if (targetPosition.HasValue)
-        {
-            var eyeAngle = (float) _eye.CurrentEye.Rotation;
-            var worldDir = targetPosition.Value - emitter.MapCoords.Position;
-            if (worldDir.LengthSquared() > 0.0001f)
-            {
-                var cosE = MathF.Cos(eyeAngle);
-                var sinE = MathF.Sin(eyeAngle);
-                var sx = worldDir.X * cosE - worldDir.Y * sinE;
-                var sy = worldDir.X * sinE + worldDir.Y * cosE;
-                emitter.EffectiveEmitAngle = MathF.Atan2(sx, sy);
-            }
-        }
-
-        _emitters.Add(emitter);
-        if (proto.IgnoreQualitySettings)
-            _ignoreQualityEmitterCount++;
-
-        if (proto.Burst)
-        {
-            BurstEmit(emitter);
-            emitter.Exhausted = true;
-        }
-
+        var emitter = SpawnEffect(effectId, coords, attachedEntity);
+        if (emitter != null)
+            emitter.TargetPosition = targetWorldPosition;
         return emitter;
     }
 
     public override void FrameUpdate(float frameTime)
     {
-        _pendingSubEmitters.Clear();
-
         // If particles are fully disabled, drop all emitters except those flagged to ignore quality settings.
         if (_quality == 0)
         {
-            for (var i = _emitters.Count - 1; i >= 0; i--)
-            {
-                var em = _emitters[i];
-                if (!RemoveNonIgnoreQualityPredicate(em))
-                    continue;
-
-                foreach (var p in em.Particles)
-                    if (p.Alive)
-                        _liveParticleCount--;
-                SwapRemoveAt(i);
-            }
+            _emitters.RemoveAll(e => !e.Proto.IgnoreQualitySettings);
             if (_emitters.Count == 0)
                 return;
         }
 
         var eye = _eye.CurrentEye;
+        var eyePos = eye.Position.Position;
         var eyeAngle = (float) eye.Rotation;
+        var halfSize = new Vector2(eye.Zoom.X > 0 ? 20f / eye.Zoom.X : 20f, eye.Zoom.Y > 0 ? 15f / eye.Zoom.Y : 15f) * 1.5f;
+        var viewBounds = new Box2(eyePos - halfSize, eyePos + halfSize);
         var currentMapId = eye.Position.MapId;
         var ageCheck = TimeSpan.FromSeconds(frameTime);
 
-        var viewport = _eye.GetWorldViewport();
-        var pad = MathF.Max(viewport.Width, viewport.Height) * (ViewBoundsPaddingFactor - 1f) * 0.5f;
-        var viewBounds = viewport.Enlarged(pad);
-
+        var remainingBudget = _globalBudget;
+        _pendingSubEmitters.Clear();
+        // Iterate emitters in reverse so we can safely remove exhausted ones by index.
+        // For each emitter: skip simulation if off-screen, otherwise deduct its live particles
+        // from the remaining budget and tick it. Remove any emitter that is exhausted and has no live particles left.
         for (var i = _emitters.Count - 1; i >= 0; i--)
         {
             var emitter = _emitters[i];
 
-            UpdateEmitterPosition(emitter, frameTime);
-            AdvanceEmitterAge(emitter, ageCheck);
+            // Check if attached entity was deleted even when off-screen.
+            if (emitter.AttachedEntity is { } attachedEnt && Deleted(attachedEnt))
+            {
+                emitter.Exhausted = true;
+                emitter.AttachedEntity = null;
+            }
 
             var inView = emitter.MapCoords.MapId == currentMapId
                 && viewBounds.Contains(emitter.MapCoords.Position);
 
             if (inView)
-                TickEmitter(emitter, frameTime, eyeAngle);
-            else
-                AgeOffScreenParticles(emitter, ageCheck);
+            {
+                foreach (var p in emitter.Particles)
+                {
+                    if (p.Alive)
+                        remainingBudget--;
+                }
+                TickEmitter(emitter, frameTime, eyeAngle, ref remainingBudget, ageCheck);
+            }
 
             if (emitter.Exhausted && !emitter.HasLiveParticles())
-            {
-                if (emitter.Proto.IgnoreQualitySettings)
-                    _ignoreQualityEmitterCount--;
-                SwapRemoveAt(i);
-            }
+                _emitters.RemoveAt(i);
         }
 
-        var processed = 0;
-        for (var subIdx = 0; subIdx < _pendingSubEmitters.Count; subIdx++)
+        // Spawn any sub-emitters collected during this tick.
+        // Use an index-based for loop instead of foreach because SpawnEffect can itself add
+        // new entries to _pendingSubEmitters (sub-emitters of sub-emitters (dont do that)), which would
+        // throw if we were iterating with an enumerator.
+        for (int subIdx = 0; subIdx < _pendingSubEmitters.Count; subIdx++)
         {
-            if (processed++ >= MaxSubEmittersPerTick)
-            {
-                Log.Warning($"Particle sub-emitter cap of {MaxSubEmittersPerTick} hit in one frame; dropping remaining spawns. Likely a SubEmitterOnSpawn cycle.");
-                break;
-            }
             var (id, coords) = _pendingSubEmitters[subIdx];
             SpawnEffect(id, coords);
-        }
-    }
-
-    private void SwapRemoveAt(int index)
-    {
-        var last = _emitters.Count - 1;
-        if (index != last)
-            _emitters[index] = _emitters[last];
-        _emitters.RemoveAt(last);
-    }
-
-    private void UpdateEmitterPosition(ActiveEmitter emitter, float dt)
-    {
-        if (emitter.AttachedEntity is not { } attachedEnt)
-        {
-            if (!emitter.VelocityInitialized)
-            {
-                emitter.PreviousPosition = emitter.MapCoords.Position;
-                emitter.VelocityInitialized = true;
-            }
-            return;
-        }
-
-        if (Deleted(attachedEnt))
-        {
-            emitter.Exhausted = true;
-            emitter.AttachedEntity = null;
-            return;
-        }
-
-        var attachedCoords = _transform.GetMapCoordinates(attachedEnt);
-        var newPos = attachedCoords.Position;
-        emitter.MapCoords = attachedCoords;
-
-        if (!emitter.VelocityInitialized)
-        {
-            emitter.PreviousPosition = newPos;
-            emitter.VelocityInitialized = true;
-            return;
-        }
-
-        var delta = newPos - emitter.PreviousPosition;
-        if (dt > 0f)
-        {
-            // Detect teleports, without this, particles inheriting velocity get sent flying off-screen
-            // when the attached entity is moved (admin teleport, jaunt, bluespace, etc etc)
-            emitter.EmitterVelocity = delta.LengthSquared() > TeleportThresholdSquared
-                ? Vector2.Zero
-                : delta / dt;
-        }
-        emitter.PreviousPosition = newPos;
-    }
-
-    private static void AdvanceEmitterAge(ActiveEmitter emitter, TimeSpan ageCheck)
-    {
-        emitter.Age += ageCheck;
-
-        if (emitter.Exhausted)
-            return;
-
-        var ovr = emitter.Overrides;
-        var duration = (float)(ovr?.Duration ?? emitter.Proto.Duration).TotalSeconds;
-        if (duration > 0f && emitter.Age.TotalSeconds >= duration)
-            emitter.Exhausted = true;
-    }
-
-    private void AgeOffScreenParticles(ActiveEmitter emitter, TimeSpan ageCheck)
-    {
-        foreach (var p in emitter.Particles)
-        {
-            if (!p.Alive)
-                continue;
-            p.Age += ageCheck;
-            if (p.Age >= p.Lifetime)
-            {
-                p.Alive = false;
-                _liveParticleCount--;
-                emitter.FreePool.Enqueue(p);
-            }
         }
     }
 
@@ -602,9 +390,37 @@ public sealed partial class ParticleSystem : EntitySystem
     /// </summary>
     public static void UpdateIntensity(ActiveEmitter emitter, float intensity) => emitter.Intensity = intensity;
 
-    private void TickEmitter(ActiveEmitter emitter, float dt, float eyeAngle)
+    private void TickEmitter(ActiveEmitter emitter, float dt, float eyeAngle, ref int remainingBudget, TimeSpan ageCheck)
     {
         var proto = emitter.Proto;
+
+        // Update attached entity position and track emitter velocity
+        var newPos = emitter.MapCoords.Position;
+        if (emitter.AttachedEntity is { } attachedEnt)
+        {
+            if (Deleted(attachedEnt))
+            {
+                emitter.Exhausted = true;
+                emitter.AttachedEntity = null;
+            }
+            else
+            {
+                var attachedCoords = _transform.GetMapCoordinates(attachedEnt);
+                newPos = attachedCoords.Position;
+                emitter.MapCoords = attachedCoords; // update both position AND MapId
+            }
+        }
+
+        if (!emitter.VelocityInitialized)
+        {
+            emitter.PreviousPosition = newPos;
+            emitter.VelocityInitialized = true;
+        }
+
+        if (dt > 0f)
+            emitter.EmitterVelocity = (newPos - emitter.PreviousPosition) / dt;
+
+        emitter.PreviousPosition = newPos;
 
         // Aim-at: recompute emit angle toward target each tick
         Vector2? targetWorldPos = null;
@@ -634,7 +450,7 @@ public sealed partial class ParticleSystem : EntitySystem
         {
             // No target, keep in sync with the overridden emit angle if set, otherwise prototype default
             var baseAngle = emitter.Overrides?.EmitAngle ?? emitter.Proto.EmitAngle;
-            emitter.EffectiveEmitAngle = (float)baseAngle.Theta;
+            emitter.EffectiveEmitAngle = (float) baseAngle.Theta;
         }
 
         // Resolve overridable scalars once per tick
@@ -645,14 +461,14 @@ public sealed partial class ParticleSystem : EntitySystem
         var gravity = ovr?.Gravity ?? proto.Gravity;
         var noiseStr = ovr?.NoiseStrength ?? proto.NoiseStrength;
         var noiseFreq = ovr?.NoiseFrequency ?? proto.NoiseFrequency;
-        var duration = (float)(ovr?.Duration ?? proto.Duration).TotalSeconds;
+        var duration = (float) (ovr?.Duration ?? proto.Duration).TotalSeconds;
         var emissionRate = ovr?.EmissionRate ?? proto.EmissionRate;
         var maxCount = ovr?.MaxCount ?? proto.MaxCount;
 
-        // Drag is exp(-drag*dt) per tick, same value for every particle. Do the math once and pass
-        // the multiplier in to not do this math every single particle..
-        var dragMul = drag > 0f ? MathF.Exp(-drag * dt) : 1f;
-        var termSpeedSq = termSpeed > 0f ? termSpeed * termSpeed : 0f;
+        // Advance age and check duration
+        emitter.Age += ageCheck;
+        if (!emitter.Exhausted && duration > 0f && emitter.Age.TotalSeconds >= duration)
+            emitter.Exhausted = true;
 
         // RSI animation
         if (emitter.Delays.Length > 0 && emitter.Frames.Length > 0)
@@ -668,17 +484,15 @@ public sealed partial class ParticleSystem : EntitySystem
             }
         }
 
-        // Simulate live particles. Death decrements _liveParticleCount so the emission caps below
-        // (which read _globalBudget - _liveParticleCount) see the freed-up capacity immediately.
-        // liveCount is the post-tick number of survivors used to enforce MaxCount below.
-        var liveCount = 0;
-        var dtSpan = TimeSpan.FromSeconds(dt);
+        // Simulate live particles
+        int liveCount = 0;
         foreach (var p in emitter.Particles)
         {
             if (!p.Alive)
                 continue;
 
-            p.Age += dtSpan;
+            liveCount++;
+            p.Age += TimeSpan.FromSeconds(dt);
 
             if (p.Age >= p.Lifetime)
             {
@@ -690,22 +504,19 @@ public sealed partial class ParticleSystem : EntitySystem
                 }
 
                 p.Alive = false;
-                _liveParticleCount--;
                 emitter.FreePool.Enqueue(p);
+                liveCount--;
                 continue;
             }
 
-            SimulateParticle(p, dt, dragMul, constForce, termSpeedSq, termSpeed, gravity, noiseStr, noiseFreq, proto);
-            liveCount++;
+            SimulateParticle(p, dt, drag, constForce, termSpeed, gravity, noiseStr, noiseFreq, proto);
         }
 
         // Timed bursts
         if (emitter.Exhausted)
             return;
 
-        var qualityMult = proto.IgnoreQualitySettings ? 1f : QualityMultipliers[Math.Clamp(_quality, 0, QualityMultipliers.Length - 1)];
-
-        for (var b = 0; b < proto.Bursts.Count; b++)
+        for (int b = 0; b < proto.Bursts.Count; b++)
         {
             if (emitter.FiredBursts[b])
                 continue;
@@ -713,39 +524,55 @@ public sealed partial class ParticleSystem : EntitySystem
             if (emitter.Age < burst.Time)
                 continue;
 
+            // Bypass quality settings for gameplay-critical particles
+            var qualityMult = proto.IgnoreQualitySettings ? 1f : QualityMultipliers[Math.Clamp(_quality, 0, QualityMultipliers.Length - 1)];
             var toEmit = (int) Math.Ceiling(burst.Count * qualityMult * emitter.Intensity);
-            for (var j = 0; j < toEmit && _liveParticleCount < _globalBudget; j++)
+            for (int j = 0; j < toEmit && remainingBudget > 0; j++)
+            {
                 EmitParticle(emitter, eyeAngle);
+                remainingBudget--;
+            }
             emitter.FiredBursts[b] = true;
         }
 
         // Continuous emission
-        // IgnoreQualitySettings emitters are capped at IgnoreQualityMaxParticles unless quality is High.
-        var effectiveMax = proto.IgnoreQualitySettings && _quality < 3
-            ? Math.Min(maxCount, IgnoreQualityMaxParticles)
-            : maxCount;
-        var scaledMax = (int) Math.Ceiling(Math.Min(effectiveMax, HardMaxParticles) * qualityMult * emitter.Intensity);
-        var capacity = _globalBudget - _liveParticleCount;
-        var canEmit = Math.Min(scaledMax - liveCount, capacity);
-        if (canEmit > 0)
+        if (!proto.Burst)
         {
-            var emissionMult = 1f;
-            if (proto.EmissionOverTime.Count > 0)
+            // Bypass quality settings for gameplay-critical particles
+            var qualityMult = proto.IgnoreQualitySettings ? 1f : QualityMultipliers[Math.Clamp(_quality, 0, QualityMultipliers.Length - 1)];
+            // IgnoreQualitySettings emitters are capped at IgnoreQualityMaxParticles unless quality is High.
+            var effectiveMax = proto.IgnoreQualitySettings && _quality < 3
+                ? Math.Min(maxCount, IgnoreQualityMaxParticles)
+                : maxCount;
+            var scaledMax = (int) Math.Ceiling(Math.Min(effectiveMax, HardMaxParticles) * qualityMult * emitter.Intensity);
+            var canEmit = Math.Min(scaledMax - liveCount, remainingBudget);
+            if (canEmit > 0)
             {
-                var t = duration > 0f
-                    ? Math.Clamp((float) (emitter.Age.TotalSeconds / duration), 0f, 1f)
-                    : Math.Clamp((float) emitter.Age.TotalSeconds, 0f, 1f);
-                emissionMult = SampleCurve(proto.EmissionOverTime, t);
+                // EmissionOverTime rate multiplier
+                float emissionMult = 1f;
+                if (proto.EmissionOverTime.Count > 0)
+                {
+                    var t = duration > 0f
+                        ? Math.Clamp((float) (emitter.Age.TotalSeconds / duration), 0f, 1f)
+                        : Math.Clamp((float) emitter.Age.TotalSeconds, 0f, 1f);
+                    emissionMult = SampleCurve(proto.EmissionOverTime, t);
+                }
+
+                emitter.EmitAccum += emissionRate * emissionMult * dt * emitter.Intensity;
+                int toEmit = (int) emitter.EmitAccum;
+                emitter.EmitAccum -= toEmit;
+                toEmit = Math.Min(toEmit, canEmit);
+
+                for (int i = 0; i < toEmit; i++)
+                {
+                    EmitParticle(emitter, eyeAngle);
+                    remainingBudget--;
+                }
             }
-
-            emitter.EmitAccum += emissionRate * emissionMult * dt * emitter.Intensity;
-            var toEmit = (int) emitter.EmitAccum;
-            emitter.EmitAccum -= toEmit;
-            toEmit = Math.Min(toEmit, canEmit);
-
-            for (var i = 0; i < toEmit; i++)
-                EmitParticle(emitter, eyeAngle);
         }
+
+        if (proto.Burst)
+            emitter.Exhausted = true;
     }
 
     private void BurstEmit(ActiveEmitter emitter)
@@ -758,12 +585,7 @@ public sealed partial class ParticleSystem : EntitySystem
         var effectiveMax = proto.IgnoreQualitySettings && _quality < 3
             ? Math.Min(proto.MaxCount, IgnoreQualityMaxParticles)
             : proto.MaxCount;
-        var count = (int) Math.Ceiling(Math.Min(effectiveMax, HardMaxParticles) * qualityMult * emitter.Intensity);
-        var capacity = _globalBudget - _liveParticleCount;
-        if (capacity <= 0)
-            return;
-        if (count > capacity)
-            count = capacity;
+        var count = (int) Math.Ceiling(Math.Min(effectiveMax, HardMaxParticles) * qualityMult);
         for (int i = 0; i < count; i++)
             EmitParticle(emitter, eyeAngle);
     }
@@ -787,7 +609,6 @@ public sealed partial class ParticleSystem : EntitySystem
         }
 
         p.Alive = true;
-        _liveParticleCount++;
 
         // Resolve spawn time overridable fields
         var ovr = emitter.Overrides;
@@ -804,8 +625,8 @@ public sealed partial class ParticleSystem : EntitySystem
         var rotSpeedVar = (float) (ovr?.RotationSpeedVariance?.Theta ?? proto.RotationSpeedVariance.Theta);
 
         p.Lifetime = TimeSpan.FromSeconds(lifetime + _random.NextFloat(-lifetimeVar, lifetimeVar));
-        if (p.Lifetime < TimeSpan.FromSeconds(MinParticleLifetimeSeconds))
-            p.Lifetime = TimeSpan.FromSeconds(MinParticleLifetimeSeconds);
+        if (p.Lifetime < TimeSpan.FromSeconds(0.05))
+            p.Lifetime = TimeSpan.FromSeconds(0.05);
 
         var spreadHalf = spreadAngle * 0.5f;
         var angle = emitter.EffectiveEmitAngle + _random.NextFloat(-spreadHalf, spreadHalf);
@@ -866,9 +687,8 @@ public sealed partial class ParticleSystem : EntitySystem
     private static void SimulateParticle(
         ParticleData p,
         float dt,
-        float dragMul,
+        float drag,
         Vector2 constForce,
-        float termSpeedSq,
         float termSpeed,
         float gravity,
         float noiseStr,
@@ -876,8 +696,8 @@ public sealed partial class ParticleSystem : EntitySystem
         ParticleEffectPrototype proto)
     {
         // Drag
-        if (dragMul != 1f)
-            p.Velocity *= dragMul;
+        if (drag > 0f)
+            p.Velocity *= MathF.Exp(-drag * dt);
 
         // ConstantForce
         if (constForce != Vector2.Zero)
@@ -897,10 +717,11 @@ public sealed partial class ParticleSystem : EntitySystem
         }
 
         // Terminal speed cap
-        if (termSpeedSq > 0f)
+        if (termSpeed > 0f)
         {
             var speedSq = p.Velocity.LengthSquared();
-            if (speedSq > termSpeedSq)
+            var capSq = termSpeed * termSpeed;
+            if (speedSq > capSq)
                 p.Velocity *= termSpeed / MathF.Sqrt(speedSq);
         }
 
@@ -918,9 +739,8 @@ public sealed partial class ParticleSystem : EntitySystem
         // Noise
         if (noiseStr > 0f)
         {
-            var noiseT = (float) p.Age.TotalSeconds * noiseFreq;
-            var nx = ValueNoise(p.NoiseOffset.X + noiseT, p.NoiseOffset.Y);
-            var ny = ValueNoise(p.NoiseOffset.X, p.NoiseOffset.Y + noiseT);
+            var nx = ValueNoise(p.NoiseOffset.X + (float) p.Age.TotalSeconds * noiseFreq, p.NoiseOffset.Y);
+            var ny = ValueNoise(p.NoiseOffset.X, p.NoiseOffset.Y + (float) p.Age.TotalSeconds * noiseFreq);
             p.LocalOffset += new Vector2(nx, ny) * noiseStr * dt;
         }
 
@@ -944,22 +764,7 @@ public sealed partial class ParticleSystem : EntitySystem
 
     private void ResolveFrames(ActiveEmitter emitter)
     {
-        var proto = emitter.Proto;
-
-        if (_frameCache.TryGetValue(proto, out var cached))
-        {
-            emitter.Frames = cached.Frames;
-            emitter.Delays = cached.Delays;
-            return;
-        }
-
-        if (_frameResolveFailures.Contains(proto))
-            return;
-
-        Texture[]? frames = null;
-        float[] delays = Array.Empty<float>();
-
-        switch (proto.Sprite)
+        switch (emitter.Proto.Sprite)
         {
             case SpriteSpecifier.Rsi rsi:
                 {
@@ -973,46 +778,27 @@ public sealed partial class ParticleSystem : EntitySystem
                     }
                     catch (Exception e)
                     {
-                        Log.Error($"Could not resolve RSI resource '{rsi.RsiPath}' for particle prototype {proto.ID}: {e}");
-                        _frameResolveFailures.Add(proto);
-                        return;
+                        Log.Error($"Could not resolve RSI resource '{rsi.RsiPath}' for particle prototype {emitter.Proto.ID}: {e}");
+                        break;
                     }
 
                     if (!resource.TryGetState(rsi.RsiState, out var state))
-                    {
-                        _frameResolveFailures.Add(proto);
-                        return;
-                    }
+                        break;
 
-                    frames = state.GetFrames(RsiDirection.South);
-                    delays = state.GetDelays();
+                    emitter.Frames = state.GetFrames(RsiDirection.South);
+                    emitter.Delays = state.GetDelays();
                     break;
                 }
             case SpriteSpecifier.Texture tex:
                 {
-                    try
-                    {
-                        frames = new[] { _sprite.Frame0(tex) };
-                    }
+                    try { emitter.Frames = new[] { _sprite.Frame0(tex) }; }
                     catch (Exception e)
                     {
-                        Log.Error($"Could not resolve sprite texture '{tex.TexturePath}' for particle prototype {proto.ID}: {e}");
-                        _frameResolveFailures.Add(proto);
-                        return;
+                        Log.Error($"Could not resolve sprite texture '{tex.TexturePath}' for particle prototype {emitter.Proto.ID}: {e}");
                     }
                     break;
                 }
         }
-
-        if (frames == null)
-        {
-            _frameResolveFailures.Add(proto);
-            return;
-        }
-
-        _frameCache[proto] = (frames, delays);
-        emitter.Frames = frames;
-        emitter.Delays = delays;
     }
 
     private Vector2 SampleEmissionShape(EmissionShapeData shape)

--- a/Content.Goobstation.Client/Particles/Visuals/FlammableParticleSystem.cs
+++ b/Content.Goobstation.Client/Particles/Visuals/FlammableParticleSystem.cs
@@ -47,38 +47,39 @@ public sealed class FlammableParticleSystem : EntitySystem
         if (!_appearance.TryGetData(ent, FireVisuals.FireStacks, out float stacks))
             stacks = 0f;
 
-        _active.TryGetValue(ent, out var state);
-
-        if (onFire)
+        if (!_active.TryGetValue(ent, out var state))
         {
-            if (state == null)
-            {
-                state = new FireState();
-                _active[ent] = state;
-            }
+            state = new FireState();
+            _active[ent] = state;
+        }
 
-            if (!state.OnFire)
-            {
-                var coords = _transform.GetMapCoordinates(ent);
-                state.SmokeEmitter = _particles.SpawnEffect(SmokeEffect, coords, ent.Owner);
-                state.FireEmitter  = _particles.SpawnEffect(FireEffect,  coords, ent.Owner);
+        if (onFire && !state.OnFire)
+        {
+            // Ignited: spawn emitter
+            var coords = _transform.GetMapCoordinates(ent);
+            state.SmokeEmitter = _particles.SpawnEffect(SmokeEffect, coords, ent.Owner);
+            state.FireEmitter  = _particles.SpawnEffect(FireEffect,  coords, ent.Owner);
 
-                if (state.SmokeEmitter != null) state.SmokeEmitter.Intensity = 1f;
-                if (state.FireEmitter != null)  state.FireEmitter.Intensity  = 1f;
+            if (state.SmokeEmitter != null) state.SmokeEmitter.Intensity = 1f;
+            if (state.FireEmitter != null)  state.FireEmitter.Intensity  = 1f;
 
-                state.OnFire = true;
-            }
+            state.OnFire = true;
+        }
+        else if (!onFire && state.OnFire)
+        {
+            // Extinguished: stop emitters
+            StopState(state);
+            state.OnFire = false;
+        }
 
+        // Update intensity on live emitters
+        if (state.OnFire && state.FireEmitter != null)
+        {
             var intensity = Math.Clamp(stacks / MaxStacks * 2f, 1f, 2f);
             if (state.FireEmitter != null)
                 state.FireEmitter.Intensity = intensity;
             if (state.SmokeEmitter != null)
                 state.SmokeEmitter.Intensity = intensity;
-        }
-        else if (state is { OnFire: true })
-        {
-            StopState(state);
-            state.OnFire = false;
         }
     }
 


### PR DESCRIPTION
aparentemente uma das funções do EyeManager.cs falha na validação de Box2 (introduzida na nossa nova versão da engine) ao ser executada no inicio do round (não tenho os detalhes completos se é isso mesmo)

logo, a utilização dessa função no sistema de particulas em FrameUpdate crashava o cliente. isso é cortesia de um commit do goob de limpeza ao fazer o port do funky. esse pr reverte esse commit e arruma o crash

deixado aberto pro @O-Verdadeiro-Biel testar