### PR TITLE
[FIX] corrige rotação de entidade spawnada via RCD

### DIFF
--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -729,12 +729,13 @@ public sealed class RCDSystem : EntitySystem
                 // Funky - end of changes
 
                 // Funky - Calculate rotation and apply it before spawning
+                var gridRotation = _transform.GetWorldRotation(gridUid);
                 var rotation = prototype.Rotation switch
                 {
-                    RcdRotation.Fixed => Angle.Zero,
-                    RcdRotation.Camera => Transform(uid).LocalRotation,
-                    RcdRotation.User => direction.ToAngle(),
-                    _ => Angle.Zero // Fallback
+                    RcdRotation.Fixed => gridRotation,
+                    RcdRotation.Camera => Transform(uid).LocalRotation + gridRotation,
+                    RcdRotation.User => direction.ToAngle() + gridRotation,
+                    _ => gridRotation // Fallback
                 };
 
                 // Convert EntityCoordinates to MapCoordinates


### PR DESCRIPTION
<!-- Você pode usar as guidelines dos space-wizards: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: Toda alteração submetida a esse repositório SEMPRE será licenciada em AGPL-3.0-or-later. -->
<!--- LICENSE: AGPL -->

## Sobre a PR
a entidade spawnada pelo RCD é alinhado com o norte do mapa, ou seja, a rotação do espaço, essa correção faz com que seja usado de referencia a rotação que o grid esteja em relação ao norte do espaço, assim ficando correto

## Por quê? / Balanceamento
Correção de bug

## Detalhes Técnicos
<!-- Mudanças do codigo para uma review mais facil (opcional). -->

## Anexos
<!-- Imagens ou videos sobre as mudanças da PR (opcional | recomendado). -->

## Requerimentos
<!-- Confirme colocando X entre os colchetes [X]: -->
- [X] Eu li e estou seguindo a [Politica de pull requests e changelog](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] Eu adicionei anexos à esta PR ou não precisa de imagens in-game.

**Changelog**
:cl:
- fix: Corrige bug do RCD que spawnava as entidades na rotação incorreta.
